### PR TITLE
Allow cogc file to be linked via static archive

### DIFF
--- a/Learn/Simple Libraries/Convert/libadcACpropab/adcACpropab.c
+++ b/Learn/Simple Libraries/Convert/libadcACpropab/adcACpropab.c
@@ -7,7 +7,7 @@
  * Copyright (C) Parallax, Inc. 2013. All Rights MIT Licensed.
  *
  * @brief Launch ADC124S021 process into cogc cog.
- * @n @n <b><i>CONSTRUCTION ZONE:</i></b> This library is preliminary, major revisions 
+ * @n @n <b><i>CONSTRUCTION ZONE:</i></b> This library is preliminary, major revisions
  * pending, not for release.
  */
 
@@ -15,7 +15,7 @@
 #include "adcACpropab.h"
 
 static int cog = 0;
-static AdcBox_st adcbox;  
+static AdcBox_st adcbox;
 
 int adc_start(int doPin, int diPin, int clkPin, int csPin, int pattern, int* arrayAddr)
 {
@@ -36,10 +36,10 @@ int adc_start(int doPin, int diPin, int clkPin, int csPin, int pattern, int* arr
   }
   adcbox.mailbox.stidx = i;
 
-  extern unsigned int _load_start_adcACpropab_cog[];
-  cog = cognew(_load_start_adcACpropab_cog, &adcbox.mailbox) + 1;
+  extern const unsigned int *adcACpropab_code;
+  cog = cognew(adcACpropab_code, &adcbox.mailbox) + 1;
 
-  int temp; 
+  int temp;
   while(1)
   {
     if(*(arrayAddr+i) != -1) return cog;

--- a/Learn/Simple Libraries/Convert/libadcACpropab/adcACpropab.cogc
+++ b/Learn/Simple Libraries/Convert/libadcACpropab/adcACpropab.cogc
@@ -6,10 +6,10 @@
  * @copyright
  * Copyright (C) Parallax, Inc. 2013. All Rights MIT Licensed.
  *
- * @brief Signals ADC124S021 chip.  Current rate is about 70 ksps.  I'm hoping to 
+ * @brief Signals ADC124S021 chip.  Current rate is about 70 ksps.  I'm hoping to
  * clean it up and get closer to 100 in this COGC version.  Will probably use ASM
  * to squeeze some more out of it.
- * @n @n <b><i>CONSTRUCTION ZONE:</i></b> This library is preliminary, major revisions 
+ * @n @n <b><i>CONSTRUCTION ZONE:</i></b> This library is preliminary, major revisions
  * pending, not for release.
  */
 
@@ -18,28 +18,28 @@
 
 #define clockfreq (*(int*) 0)
 
-static _COGMEM AdcMailbox_st *mbox;
-static _COGMEM int* addr;
-static _COGMEM int* ptr;
-static _COGMEM chNow, chThen;
-static _COGMEM dout, din, clk, cs, mask;
-static _COGMEM ndout, ndin, nclk, ncs;
-static _COGMEM val, i, doutval, dinval, state;
-
-_NAKED 
+_NAKED
 void main(void)
 {
+  AdcMailbox_st *mbox;
+  unsigned int* addr;
+  unsigned int* ptr;
+  int chNow, chThen;
+  int dout, din, clk, cs, mask;
+  int ndout, ndin, nclk, ncs;
+  int val, i, doutval, dinval, state;
+
   mbox = (AdcMailbox_st*) PAR;
-  dout = (1 << mbox->dout); 
-  ndout = ~dout; 
+  dout = (1 << mbox->dout);
+  ndout = ~dout;
   doutval = mbox->dout;
-  din = (1 << mbox->din); 
-  ndin = ~din; 
+  din = (1 << mbox->din);
+  ndin = ~din;
   dinval = mbox->din;
-  clk = (1 << mbox->clk); 
-  nclk = ~clk; 
-  cs = (1 << mbox->cs); 
-  ncs = ~cs; 
+  clk = (1 << mbox->clk);
+  nclk = ~clk;
+  cs = (1 << mbox->cs);
+  ncs = ~cs;
   mask = mbox->mask;
   addr = mbox->addr;
   OUTA |= cs;                                 // high(cs);
@@ -52,7 +52,7 @@ void main(void)
   OUTA &= ncs;                                // low(cs);
   DIRA |= (1 << 26);
   OUTA &= ~(1 << 26);
- 
+
   chNow = mbox->stidx;
   chThen = mbox->stidx;
 
@@ -73,14 +73,14 @@ void main(void)
           OUTA |= din;
         }
         else
-        { 
+        {
           OUTA &= ndin;
         }
         state = INA;                          //   val = val + (get_state(dout) & 1);
         state &= dout;
         state = state >> doutval;
         val += state;
-      }                                       
+      }
       chNow >>= 12;
       ptr = addr + chThen;
       *ptr = val;
@@ -91,6 +91,9 @@ void main(void)
     OUTA ^= (1 << 26);
   }
 }
+
+extern unsigned int _load_start_adcACpropab_cog[];
+const unsigned int *adcACpropab_code = _load_start_adcACpropab_cog;
 
 /**
  * TERMS OF USE: MIT License


### PR DESCRIPTION
First, sorry about the whitespace changes - my editor automatically removes trailing whitespace. I can fix that and overwrite this commit if it matters to you.

This change comes from a recommendation by [Eric Smith from Nov 2014](http://forums.parallax.com/discussion/comment/1302798/#Comment_1302798).

> As I think David Betz has already mentioned, the issue is that no symbols from cogcB.cog are being used, so it's not being pulled out of the library for linking. The `__load_start_XXX` symbol is *not* part of the .cog file, it's created by the linker only after the .cog file is added to the link, so that symbol cannot be used to force the link -- it's a chicken and egg problem. We actually need to reference something from
the .cog file itself.
> 
> Any symbol in the .cog file that's used in the main program will force the link. A simple way to do this is to declare a variable in the .cogc file like:
> 
> ```
> extern unsigned int _load_start_toggle_fw_cog[];
> const unsigned int *toggle_fw_code = _load_start_toggle_fw_cog;
> ```
>
> Then have the cognew function use `toggle_fw_code` instead of `_load_start_toggle_fw_code`.
> 
> This works because `toggle_fw_code` will be a symbol defined in the .cog file itself (not linker created) and so any reference to it will cause the .cog file to be linked.
> 
> I've updated the cog_c_toggle demo in the default branch to demonstrate this approach.

I've checked and `adcACpropab.cogc` is the only cogc file in the Learn folder. This change opens up the door to allow all of the Learn folder to be 100% compatible with PropWare's build system, instead of only SimpleIDE's internal build system.

I do not myself have an Activity Board to test the changes. I therefore provided a binary to forums users and requested that the community test it for me. I'm unable to determine whether the code still operates correctly based the responses and therefore request your observations as well.
http://forums.parallax.com/discussion/163202/activity-board-testing-request