### PR TITLE
Remove carrots after /// which were causing HTML parser errors in Doxygen docs

### DIFF
--- a/Learn/Simple Libraries/Audio/libsound/sound.h
+++ b/Learn/Simple Libraries/Audio/libsound/sound.h
@@ -1,19 +1,19 @@
 /**
   @file sound.h
-  
+
   @author Parallax Inc.
-  
+
   @brief Functions for creating tones.  4 channels, tone waveform
-  options include sine, square, triangle, and saw.  Incorporates 
-  Spin to C translation of sound components from Brett Weir's 
+  options include sine, square, triangle, and saw.  Incorporates
+  Spin to C translation of sound components from Brett Weir's
   LameStation package.
- 
-  @version 0.5 
+
+  @version 0.5
 
   @copyright
   Copyright (c) Parallax Inc 2015. All rights MIT licensed;
                 see end of file.
-*/  
+*/
                                                                              //
 #ifndef __SOUND_H
 #define __SOUND_H
@@ -50,155 +50,155 @@ extern "C"
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
                                               //
-#define SQUARE 0                             ///< Square wave
-#define SAW 1                                ///< Saw wave
-#define TRIANGLE 2                           ///< Triangle wave
-#define SINE 3                               ///< Sine wave
-#define NOISE 4                              ///< Noise
-#define INC_HZ 52.4588                        ///< Value for 1 Hz
+#define SQUARE 0                             /// Square wave
+#define SAW 1                                /// Saw wave
+#define TRIANGLE 2                           /// Triangle wave
+#define SINE 3                               /// Sine wave
+#define NOISE 4                              /// Noise
+#define INC_HZ 52.4588                        /// Value for 1 Hz
 
 #ifndef MUSIC_NOTES
-#define MUSIC_NOTES                           ///< Music note list for sound library
+#define MUSIC_NOTES                           /// Music note list for sound library
 
-#define REST     (float) 255                  ///< Notes player rest
-#define END      (float) 254                  ///< Notes player end
-#define BEAT_VAL (float) 253                  ///< Notes player beat value
-#define TEMPO    (float) 252                  ///< Notes player tempo rate
-#define HOLDS    (float) 251                  ///< Notes player holds 
-#define CH0      (float) 250                  ///< Notes player channel 0
-#define CH1      (float) 249                  ///< Notes player channel 1
-#define CH2      (float) 248                  ///< Notes player channel 2
-#define CH3      (float) 247                  ///< Notes player channel 3
-#define HOLD0    (float) 246                  ///< Notes player hold channel 0
-#define HOLD1    (float) 245                  ///< Notes player hold channel 1
-#define HOLD2    (float) 244                  ///< Notes player hold channel 2
-#define HOLD3    (float) 243                  ///< Notes player hold channel 3
-
-
-#define C0        (float) 0                   ///< Note C0
-#define D0b       (float) 1                   ///< Note D0b/C0#
-#define D0        (float) 2                   ///< Note D0
-#define E0b       (float) 3                   ///< Note E0b/E0#
-#define E0        (float) 4                   ///< Note E0
-#define F0        (float) 5                   ///< Note F0
-#define G0b       (float) 6                   ///< Note G0b/F0#
-#define G0        (float) 7                   ///< Note G0
-#define A0b       (float) 8                   ///< Note A0b/G0#
-#define A0        (float) 9                   ///< Note A0
-#define B0b       (float) 10                  ///< Note B0b/A0#
-#define B0        (float) 11                  ///< Note B0
+#define REST     (float) 255                  /// Notes player rest
+#define END      (float) 254                  /// Notes player end
+#define BEAT_VAL (float) 253                  /// Notes player beat value
+#define TEMPO    (float) 252                  /// Notes player tempo rate
+#define HOLDS    (float) 251                  /// Notes player holds
+#define CH0      (float) 250                  /// Notes player channel 0
+#define CH1      (float) 249                  /// Notes player channel 1
+#define CH2      (float) 248                  /// Notes player channel 2
+#define CH3      (float) 247                  /// Notes player channel 3
+#define HOLD0    (float) 246                  /// Notes player hold channel 0
+#define HOLD1    (float) 245                  /// Notes player hold channel 1
+#define HOLD2    (float) 244                  /// Notes player hold channel 2
+#define HOLD3    (float) 243                  /// Notes player hold channel 3
 
 
-#define C1        (float) 12                  ///< Note C1
-#define D1b       (float) 13                  ///< Note D1b/C1#
-#define D1        (float) 14                  ///< Note D1
-#define E1b       (float) 15                  ///< Note E1b/E1#
-#define E1        (float) 16                  ///< Note E1
-#define F1        (float) 17                  ///< Note F1
-#define G1b       (float) 18                  ///< Note G1b/F1#
-#define G1        (float) 19                  ///< Note G1
-#define A1b       (float) 20                  ///< Note A1b/G1#
-#define A1        (float) 21                  ///< Note A1
-#define B1b       (float) 22                  ///< Note B1b/A1#
-#define B1        (float) 23                  ///< Note B1
+#define C0        (float) 0                   /// Note C0
+#define D0b       (float) 1                   /// Note D0b/C0#
+#define D0        (float) 2                   /// Note D0
+#define E0b       (float) 3                   /// Note E0b/E0#
+#define E0        (float) 4                   /// Note E0
+#define F0        (float) 5                   /// Note F0
+#define G0b       (float) 6                   /// Note G0b/F0#
+#define G0        (float) 7                   /// Note G0
+#define A0b       (float) 8                   /// Note A0b/G0#
+#define A0        (float) 9                   /// Note A0
+#define B0b       (float) 10                  /// Note B0b/A0#
+#define B0        (float) 11                  /// Note B0
 
 
-#define C2        (float) 24                  ///< Note C2
-#define D2b       (float) 25                  ///< Note D2b/C2#
-#define D2        (float) 26                  ///< Note D2
-#define E2b       (float) 27                  ///< Note E2b/E2#
-#define E2        (float) 28                  ///< Note E2
-#define F2        (float) 29                  ///< Note F2
-#define G2b       (float) 30                  ///< Note G2b/F2#
-#define G2        (float) 31                  ///< Note G2
-#define A2b       (float) 32                  ///< Note A2b/G2#
-#define A2        (float) 33                  ///< Note A2
-#define B2b       (float) 34                  ///< Note B2b/A2#
-#define B2        (float) 35                  ///< Note B2
+#define C1        (float) 12                  /// Note C1
+#define D1b       (float) 13                  /// Note D1b/C1#
+#define D1        (float) 14                  /// Note D1
+#define E1b       (float) 15                  /// Note E1b/E1#
+#define E1        (float) 16                  /// Note E1
+#define F1        (float) 17                  /// Note F1
+#define G1b       (float) 18                  /// Note G1b/F1#
+#define G1        (float) 19                  /// Note G1
+#define A1b       (float) 20                  /// Note A1b/G1#
+#define A1        (float) 21                  /// Note A1
+#define B1b       (float) 22                  /// Note B1b/A1#
+#define B1        (float) 23                  /// Note B1
 
 
-#define C3        (float) 36                  ///< Note C3
-#define D3b       (float) 37                  ///< Note D3b/C3# 
-#define D3        (float) 38                  ///< Note D3
-#define E3b       (float) 39                  ///< Note E3b/E3#
-#define E3        (float) 40                  ///< Note E3
-#define F3        (float) 41                  ///< Note F3
-#define G3b       (float) 42                  ///< Note G3b/F3#
-#define G3        (float) 43                  ///< Note G3
-#define A3b       (float) 44                  ///< Note A3b/G3#
-#define A3        (float) 45                  ///< Note A3
-#define B3b       (float) 46                  ///< Note B3b/A3#
-#define B3        (float) 47                  ///< Note B3
+#define C2        (float) 24                  /// Note C2
+#define D2b       (float) 25                  /// Note D2b/C2#
+#define D2        (float) 26                  /// Note D2
+#define E2b       (float) 27                  /// Note E2b/E2#
+#define E2        (float) 28                  /// Note E2
+#define F2        (float) 29                  /// Note F2
+#define G2b       (float) 30                  /// Note G2b/F2#
+#define G2        (float) 31                  /// Note G2
+#define A2b       (float) 32                  /// Note A2b/G2#
+#define A2        (float) 33                  /// Note A2
+#define B2b       (float) 34                  /// Note B2b/A2#
+#define B2        (float) 35                  /// Note B2
 
 
-#define C4        (float) 48                  ///< Note C4
-#define D4b       (float) 49                  ///< Note D4b/C4#
-#define D4        (float) 50                  ///< Note D4
-#define E4b       (float) 51                  ///< Note E4b/E4#
-#define E4        (float) 52                  ///< Note E4
-#define F4        (float) 53                  ///< Note F4
-#define G4b       (float) 54                  ///< Note G4b/F4#
-#define G4        (float) 55                  ///< Note G4
-#define A4b       (float) 56                  ///< Note A4b/G4#
-#define A4        (float) 57                  ///< Note A4
-#define B4b       (float) 58                  ///< Note B4b/A4#
-#define B4        (float) 59                  ///< Note B4
+#define C3        (float) 36                  /// Note C3
+#define D3b       (float) 37                  /// Note D3b/C3#
+#define D3        (float) 38                  /// Note D3
+#define E3b       (float) 39                  /// Note E3b/E3#
+#define E3        (float) 40                  /// Note E3
+#define F3        (float) 41                  /// Note F3
+#define G3b       (float) 42                  /// Note G3b/F3#
+#define G3        (float) 43                  /// Note G3
+#define A3b       (float) 44                  /// Note A3b/G3#
+#define A3        (float) 45                  /// Note A3
+#define B3b       (float) 46                  /// Note B3b/A3#
+#define B3        (float) 47                  /// Note B3
 
 
-#define C5        (float) 60                  ///< Note C5
-#define D5b       (float) 61                  ///< Note D5b/C5#
-#define D5        (float) 62                  ///< Note D5
-#define E5b       (float) 63                  ///< Note E5b/E5#
-#define E5        (float) 64                  ///< Note E5
-#define F5        (float) 65                  ///< Note F5
-#define G5b       (float) 66                  ///< Note G5b/F5#
-#define G5        (float) 67                  ///< Note G5
-#define A5b       (float) 68                  ///< Note A5b/G5#
-#define A5        (float) 69                  ///< Note A5
-#define B5b       (float) 70                  ///< Note B5b/A5#
-#define B5        (float) 71                  ///< Note B5
+#define C4        (float) 48                  /// Note C4
+#define D4b       (float) 49                  /// Note D4b/C4#
+#define D4        (float) 50                  /// Note D4
+#define E4b       (float) 51                  /// Note E4b/E4#
+#define E4        (float) 52                  /// Note E4
+#define F4        (float) 53                  /// Note F4
+#define G4b       (float) 54                  /// Note G4b/F4#
+#define G4        (float) 55                  /// Note G4
+#define A4b       (float) 56                  /// Note A4b/G4#
+#define A4        (float) 57                  /// Note A4
+#define B4b       (float) 58                  /// Note B4b/A4#
+#define B4        (float) 59                  /// Note B4
 
 
-#define C6        (float) 72                  ///< Note C6
-#define D6b       (float) 73                  ///< Note D6b/C6# 
-#define D6        (float) 74                  ///< Note D6
-#define E6b       (float) 75                  ///< Note E6b/E6#
-#define E6        (float) 76                  ///< Note E6
-#define F6        (float) 77                  ///< Note F6
-#define G6b       (float) 78                  ///< Note G6b/F6#
-#define G6        (float) 79                  ///< Note G6
-#define A6b       (float) 80                  ///< Note A6b/G6#
-#define A6        (float) 81                  ///< Note A6
-#define B6b       (float) 82                  ///< Note B6b/A6#
-#define B6        (float) 83                  ///< Note B6
+#define C5        (float) 60                  /// Note C5
+#define D5b       (float) 61                  /// Note D5b/C5#
+#define D5        (float) 62                  /// Note D5
+#define E5b       (float) 63                  /// Note E5b/E5#
+#define E5        (float) 64                  /// Note E5
+#define F5        (float) 65                  /// Note F5
+#define G5b       (float) 66                  /// Note G5b/F5#
+#define G5        (float) 67                  /// Note G5
+#define A5b       (float) 68                  /// Note A5b/G5#
+#define A5        (float) 69                  /// Note A5
+#define B5b       (float) 70                  /// Note B5b/A5#
+#define B5        (float) 71                  /// Note B5
 
 
-#define C7        (float) 84                  ///< Note C7
-#define D7b       (float) 85                  ///< Note D7b/C7# 
-#define D7        (float) 86                  ///< Note D7
-#define E7b       (float) 87                  ///< Note E7b/E7#
-#define E7        (float) 88                  ///< Note E7
-#define F7        (float) 89                  ///< Note F7
-#define G7b       (float) 90                  ///< Note G7b/F7#
-#define G7        (float) 91                  ///< Note G7
-#define A7b       (float) 92                  ///< Note A7b/G7#
-#define A7        (float) 93                  ///< Note A7
-#define B7b       (float) 94                  ///< Note B7b/A7#
-#define B7        (float) 95                  ///< Note B7
+#define C6        (float) 72                  /// Note C6
+#define D6b       (float) 73                  /// Note D6b/C6#
+#define D6        (float) 74                  /// Note D6
+#define E6b       (float) 75                  /// Note E6b/E6#
+#define E6        (float) 76                  /// Note E6
+#define F6        (float) 77                  /// Note F6
+#define G6b       (float) 78                  /// Note G6b/F6#
+#define G6        (float) 79                  /// Note G6
+#define A6b       (float) 80                  /// Note A6b/G6#
+#define A6        (float) 81                  /// Note A6
+#define B6b       (float) 82                  /// Note B6b/A6#
+#define B6        (float) 83                  /// Note B6
 
 
-#define C8        (float) 96                  ///< Note C8
-#define D8b       (float) 97                  ///< Note D8b/C8#
-#define D8        (float) 98                  ///< Note D8
-#define E8b       (float) 99                  ///< Note E8b/E8#
-#define E8        (float) 100                 ///< Note E8
-#define F8        (float) 101                 ///< Note F8
-#define G8b       (float) 102                 ///< Note G8b/F8#
-#define G8        (float) 103                 ///< Note G8
-#define A8b       (float) 104                 ///< Note A8b/G8#
-#define A8        (float) 105                 ///< Note A8
-#define B8b       (float) 106                 ///< Note B8b/A8#
-#define B8        (float) 107                 ///< Note B8
+#define C7        (float) 84                  /// Note C7
+#define D7b       (float) 85                  /// Note D7b/C7#
+#define D7        (float) 86                  /// Note D7
+#define E7b       (float) 87                  /// Note E7b/E7#
+#define E7        (float) 88                  /// Note E7
+#define F7        (float) 89                  /// Note F7
+#define G7b       (float) 90                  /// Note G7b/F7#
+#define G7        (float) 91                  /// Note G7
+#define A7b       (float) 92                  /// Note A7b/G7#
+#define A7        (float) 93                  /// Note A7
+#define B7b       (float) 94                  /// Note B7b/A7#
+#define B7        (float) 95                  /// Note B7
+
+
+#define C8        (float) 96                  /// Note C8
+#define D8b       (float) 97                  /// Note D8b/C8#
+#define D8        (float) 98                  /// Note D8
+#define E8b       (float) 99                  /// Note E8b/E8#
+#define E8        (float) 100                 /// Note E8
+#define F8        (float) 101                 /// Note F8
+#define G8b       (float) 102                 /// Note G8b/F8#
+#define G8        (float) 103                 /// Note G8
+#define A8b       (float) 104                 /// Note A8b/G8#
+#define A8        (float) 105                 /// Note A8
+#define B8b       (float) 106                 /// Note B8b/A8#
+#define B8        (float) 107                 /// Note B8
 
 #endif  // MUSIC_NOTES
 
@@ -208,7 +208,7 @@ extern "C"
   typedef struct audiosynthpasm_struct
   {
     volatile int osc_sample;
-    volatile int osc_envelope;            
+    volatile int osc_envelope;
     volatile int osc_attack;
     volatile int osc_decay;
     volatile int osc_sustain;
@@ -229,82 +229,82 @@ extern "C"
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-typedef sound_t sound;                        ///< Sound process ID & pointer
+typedef sound_t sound;                        /// Sound process ID & pointer
 
 
 /**
   @brief start a talk process, uses a cog.
-  
+
   @param pin An I/O pin to deliver signals.  Use -1 if you don't want
   to use this I/O pin.
-  
+
   @param npin An I/O pin to deliver the opposite of the pin signals.
   This is useful for differential signaling or sound over two headphone
   channels.  Use -1 if you don't want to use this I/O pin.
-  
+
   @returns A pointer to the talk process info for use as a process ID
-  in other function calls. 
+  in other function calls.
 */
 sound_t *sound_run(int pin, int npin);
 
 
 /**
   @brief stop a talk process and recover a cog.
-  
-  @param *device The pointer returned by talk_start that indicates 
+
+  @param *device The pointer returned by talk_start that indicates
   which talk process is to be stopped.
-*/  
+*/
 void sound_end(sound_t *device);
 
 /**
   @brief Set volume for one of the sound process' four channels
-  
+
   @param *device Sound process ID, the pointer to the sound process
   info returned by sound_run.
-  
+
   @param channel 0, 1, 2, or 3.
-  
+
   @param volume 0 to 127.
-*/  
+*/
 void sound_volume(sound_t *device, int channel, int volume);
 
 /**
   @brief Make one of the sound process' four channels play a note.
-  
+
   @param *device Sound process ID, the pointer to the sound process
   info returned by sound_run.
 
   @param channel 0, 1, 2, or 3.
 
-  @param note From C0 (0) to B8 (107), append with b for flat notes.  
-*/  
+  @param note From C0 (0) to B8 (107), append with b for flat notes.
+*/
 void sound_note(sound_t *device, int channel, int note);
 
 /**
   @brief Set the waveform of one of the process' four channels
-  
+
   @param *device Sound process ID, the pointer to the sound process
   info returned by sound_run.
 
   @param channel 0, 1, 2, or 3.
 
   @param wave SQARE, SAW, TRIANGLE, SINE, or NOISE.
-*/  
+*/
 void sound_wave(sound_t *device, int channel, int wave);
 
 /**
   @brief Set Hz the frequency transmitted by one of the sound process'
   four channels.
-  
+
   @param *device Sound process ID, the pointer to the sound process
   info returned by sound_run.
 
   @param channel 0, 1, 2, or 3.
 
   @param freq Hz from 1 to 20 k.
-  
-  @returns 
-*/  
+
+  @returns
+*/
 void sound_freq(sound_t *device, int channel, int freq);
 
 
@@ -312,18 +312,18 @@ void sound_freq(sound_t *device, int channel, int freq);
 
   void sound_freqRaw(sound_t *device, int channel, int value);
 
-  void sound_adsr(sound_t *device, int channel, int attack,  int decay, 
+  void sound_adsr(sound_t *device, int channel, int attack,  int decay,
                                                 int sustain, int release);
   void sound_envelopeSet(sound_t *device, int channel, int value);
   void sound_envelopeStart(sound_t *device, int channel, int enable);
-  
+
   void sound_playChords(sound_t *device, float *chords);
-  
+
   void replace_byte(int *address, int intOffset, int byteOffset, int newVal);
   void sound_param(sound_t *device, int type, int channel, int value);
   void sound_loadPatch(sound_t *device, int *patchAddr);
   void sound_sampleSet(sound_t *device, int value);
-  
+
   void sound_playSound(sound_t *device, int channel, int value);
   void sound_endSound(sound_t *device, int channel);
   void sound_endAllSound(sound_t *device);
@@ -334,23 +334,23 @@ void sound_freq(sound_t *device, int channel, int freq);
 }
 #endif
 /* __cplusplus */
-#endif 
+#endif
 /* __SOUND_H */
 
 
 /*
   TERMS OF USE: MIT License
- 
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation
   the rights to use, copy, modify, merge, publish, distribute, sublicense,
   and/or sell copies of the Software, and to permit persons to whom the
   Software is furnished to do so, subject to the following conditions:
- 
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
- 
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/Learn/Simple Libraries/Time/libdatetime/datetime.h
+++ b/Learn/Simple Libraries/Time/libdatetime/datetime.h
@@ -1,22 +1,22 @@
 /**
   @file datetime.h
-  
+
   @author Parallax Inc.
-  
-  @brief This library provides convenient functions for a 
+
+  @brief This library provides convenient functions for a
   variety of timekeeping operations.  This library makes use of
-  a manual Spin to C translation of functions from Bob 
-  Belleville's date_time_epoch.spin for converting to/from 
-  between epoch time (seconds from midnight, 1/1/1970) and a 
+  a manual Spin to C translation of functions from Bob
+  Belleville's date_time_epoch.spin for converting to/from
+  between epoch time (seconds from midnight, 1/1/1970) and a
   datetime format.
- 
-  @version 0.6 
+
+  @version 0.6
 
   @copyright
   Copyright (c) Parallax Inc 2015. All rights MIT licensed;
                 see end of file.
-*/  
-                                                                             //
+*/
+
 
 #ifndef DATETIME_H
 #define DATETIME_H
@@ -27,65 +27,65 @@ extern "C" {
 
 #ifndef SECONDS
 /**
- * @brief Constant 1 for 1 second.  
+ * @brief Constant 1 for 1 second.
  */
 #define SECONDS 1
 #endif
 
 #ifndef MINUTES
 /**
- * @brief Constant 60 for seconds in a minute.  
+ * @brief Constant 60 for seconds in a minute.
  */
 #define MINUTES 60
 #endif
 
 #ifndef HOURS
 /**
- * @brief Constant 3600 for seconds in an hour.  
+ * @brief Constant 3600 for seconds in an hour.
  */
 #define HOURS   60 * MINUTES
 #endif
 
 #ifndef DAYS
 /**
- * @brief Constant 86400 for seconds in a day.  
+ * @brief Constant 86400 for seconds in a day.
  */
 #define DAYS    24 * HOURS
 #endif
 
-typedef struct datetime_st ///< datetime_st Structure containing y, mo, h, m, and s elements.
-{ 
-  volatile int y; ///< Year          
-  volatile int mo; ///< Month   
-  volatile int d; ///< Day   
-  volatile int h; ///< Hour   
-  volatile int m; ///< Minute   
-  volatile int s; ///< Second   
-} datetime; ///< datetime Type definition of datetime_st structure. 
+typedef struct datetime_st /// datetime_st Structure containing y, mo, h, m, and s elements.
+{
+  volatile int y; /// Year
+  volatile int mo; /// Month
+  volatile int d; /// Day
+  volatile int h; /// Hour
+  volatile int m; /// Minute
+  volatile int s; /// Second
+} datetime; /// datetime Type definition of datetime_st structure.
 
 
 /**
  * @brief Run a date/time second counting process in another cog.
- * Example: datetime dts = {2015, 9, 25, 8, 11, 04};  
+ * Example: datetime dts = {2015, 9, 25, 8, 11, 04};
  * dt_run(dts);
- * 
- * @param dt A datetime structure, pre-set before the call.  
+ *
+ * @param dt A datetime structure, pre-set before the call.
  */
 void dt_run(datetime dt);
 
 /**
- * @brief Stop a date/time second counting process and recover the 
+ * @brief Stop a date/time second counting process and recover the
  * cog and lock.
  */
 void dt_end();
 
 /**
- * @brief Set the system date and time.  This can be used to change the 
- * system's current date/time.  Example datetime mydt={2015, 9, 25, 8, 
- * 13, 51}; dt_set(mydt);  You can also use this to change the datetime 
- * type that was used in dt_start to "set" the second counter that 
+ * @brief Set the system date and time.  This can be used to change the
+ * system's current date/time.  Example datetime mydt={2015, 9, 25, 8,
+ * 13, 51}; dt_set(mydt);  You can also use this to change the datetime
+ * type that was used in dt_start to "set" the second counter that
  * auto-increments.
- * 
+ *
  * @param dt A datetime type containing the new date and time.
  */
 void dt_set(datetime dt);
@@ -93,9 +93,9 @@ void dt_set(datetime dt);
 /**
  * @brief Get the current system time.  To find the current system
  * time (as a datetime type), call this function.  Note: This assumes
- * that a call to dt_run has been made.  This is common near the 
- * beginning of a program that uses the system timekeeping.  
- * 
+ * that a call to dt_run has been made.  This is common near the
+ * beginning of a program that uses the system timekeeping.
+ *
  * @returns The datetime representation of the current system time.
  */
 datetime dt_get();
@@ -103,30 +103,30 @@ datetime dt_get();
 /**
  * @brief Get the number of ms into the current second from the system
  * time second. Notes: This assumes that a call to dt_run has been made.
- * This is common near the beginning of a program that uses the system 
+ * This is common near the beginning of a program that uses the system
  * timekeeping.  The current second can be captured with dt_get.
- * 
+ *
  * @returns Milliseconds since into the current second.  This second .
  */
 int dt_getms();
 
 /**
- * @brief Get the Unix epoch time (number of seconds from Midnight, 1/1/1970) 
- * from a datetime type.  This number is a common form of timekeeping for 
+ * @brief Get the Unix epoch time (number of seconds from Midnight, 1/1/1970)
+ * from a datetime type.  This number is a common form of timekeeping for
  * computer systems.
- * 
+ *
  * @param dt A datetime type that contains a valid date and time.
- * 
+ *
  * @returns et The number of seconds that date is from Midnight, 1/1/1970.
  */
 int dt_toEt(datetime dt);
 
 /**
- * @brief Get the datetime representation of an a Unix epoch time (number 
- * of seconds from Midnight, 1/1/1970).  
- * 
+ * @brief Get the datetime representation of an a Unix epoch time (number
+ * of seconds from Midnight, 1/1/1970).
+ *
  * @param et The number of seconds that date is from Midnight, 1/1/1970.
- * 
+ *
  * @returns dt A datetime type with the equivalent date and time.
  */
 datetime dt_fromEt(int et);
@@ -134,9 +134,9 @@ datetime dt_fromEt(int et);
 /**
  * @brief Populates a string (minimum 9 characters) with the mm/dd/yy
  * representation of a datetime type's date.
- * 
+ *
  * @param dt Datetime type containing a valid date.
- * 
+ *
  * @param *s String (minimum 9 characters) address.
  */
 void dt_toDateStr(datetime dt, char *s);
@@ -144,9 +144,9 @@ void dt_toDateStr(datetime dt, char *s);
 /**
  * @brief Populates a string (minimum 9 characters) with the hh:mm:ss
  * representation of a datetime type's time.
- * 
+ *
  * @param dt Datetime type containing a valid time.
- * 
+ *
  * @param *s String (minimum 9 characters) address.
  */
 void dt_toTimeStr(datetime dt, char *s);
@@ -155,30 +155,30 @@ void dt_toTimeStr(datetime dt, char *s);
  * @brief Populates the y, mo, and d fields in a datetime type with
  * value representations of the characters in a string that contains
  * the date in mm/dd/yy format.
- * 
+ *
  * @param dt Datetime type.  This datetime type may already contain
  * a time that will be unaffected.  Only the date (y, mo, d) fields
  * will be changed.
- * 
+ *
  * @param *s String (minimum 9 characters) containing the date in
  * mm/dd/yy format.
- * 
+ *
  * @returns A copy of the datetime type with updated date fields.
  */
 datetime dt_fromDateStr(datetime dt, char *s);
 
 /**
- * @brief Populates the time fields (h, m, and s) in a datetime type 
- * with value representations of the characters in a string that 
+ * @brief Populates the time fields (h, m, and s) in a datetime type
+ * with value representations of the characters in a string that
  * contains the time in hh/mm/ss format.
- * 
+ *
  * @param dt Datetime type.  This datetime type may already contain
  * a date that will be unaffected.  Only the date (h, m, s) fields
  * will be changed.
- * 
+ *
  * @param *s String (minimum 9 characters) containing the time in
  * hh:mm:ss format.
- * 
+ *
  * @returns A copy of the datetime type with updated time fields.
  */
 datetime dt_fromTimeStr(datetime dt, char *s);
@@ -188,19 +188,19 @@ datetime dt_fromTimeStr(datetime dt, char *s);
   #ifndef _eunix
   #define _eunix 2440588
   #endif
-  
+
   #ifndef _edos
   #define _edos 2444240
   #endif
-  
+
   #ifndef _eunix
   #define _eunix 2440588
   #endif
-  
+
   #ifndef _eprop
   #define _eprop 2451545
   #endif
-  
+
   #ifndef _epoch
   #define _epoch _eunix
   #endif
@@ -213,29 +213,29 @@ datetime dt_fromTimeStr(datetime dt, char *s);
   int dte_dateETV(int etv);
   int dte_timeETV(int etv);
   //int dte_toETV(int y, int mo, int d,int h,int m, int s);
-  
+
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 #if defined(__cplusplus)
 }
 #endif
-/* __cplusplus */  
+/* __cplusplus */
 #endif
-/* DATETIME_H */  
+/* DATETIME_H */
 
 /*
   TERMS OF USE: MIT License
- 
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
   the rights to use, copy, modify, merge, publish, distribute, sublicense,
   and/or sell copies of the Software, and to permit persons to whom the
   Software is furnished to do so, subject to the following conditions:
- 
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
- 
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL


### PR DESCRIPTION
Doxygen produces bad xhtml files (maybe HTML too, not sure) when there are comments such as "///<" in the file. The carrot at the end makes the Chrome (and maybe other browsers too?) fail to display the page. An example can be seen on PropWare's class listing here: http://david.zemon.name/PropWare/annotated.xhtml